### PR TITLE
Created utilities to help detect when environment is still in dev or test

### DIFF
--- a/utility_functions/migration_utilities/Check_For_DB_Environment.ps1
+++ b/utility_functions/migration_utilities/Check_For_DB_Environment.ps1
@@ -1,0 +1,1 @@
+Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "db_env(ironment)*[ ]*=[ ]*'\b(test|prod)\b'" > databricks_environment_err.txt

--- a/utility_functions/migration_utilities/Check_For_DB_Environment.ps1
+++ b/utility_functions/migration_utilities/Check_For_DB_Environment.ps1
@@ -1,1 +1,1 @@
-Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "db_env(ironment)*[ ]*=[ ]*'\b(test|prod)\b'" > databricks_environment_err.txt
+Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "db_env(ironment)*[ ]*=[ ]*'\b(test|prod)\b'" > databricks_environment_chk.txt

--- a/utility_functions/migration_utilities/Check_For_Environment.ps1
+++ b/utility_functions/migration_utilities/Check_For_Environment.ps1
@@ -1,1 +1,1 @@
-Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "env(ironment)*[ ]*=[ ]*'\b(DEV|TST|PRD)\b'" > environment_err.txt
+Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "env(ironment)*[ ]*=[ ]*'\b(DEV|TST|PRD)\b'" > environment_chk.txt

--- a/utility_functions/migration_utilities/Check_For_Environment.ps1
+++ b/utility_functions/migration_utilities/Check_For_Environment.ps1
@@ -1,0 +1,1 @@
+Get-ChildItem -Path . -Filter *.py -Recurse | Select-String -Pattern "env(ironment)*[ ]*=[ ]*'\b(DEV|TST|PRD)\b'" > environment_err.txt

--- a/utility_functions/migration_utilities/Create_Test_Profile.bat
+++ b/utility_functions/migration_utilities/Create_Test_Profile.bat
@@ -1,0 +1,4 @@
+call C:/Users/u00xbg/AppData/Local/Continuum/anaconda3/Scripts/activate.bat
+databricks configure --profile test_profile
+
+exit

--- a/utility_functions/migration_utilities/Readme.md
+++ b/utility_functions/migration_utilities/Readme.md
@@ -3,8 +3,7 @@ Author: Rich Winkler
 The scripts within this folder will assist in identifying any locations where environments have been hardcoded in scripts and should be changed when migrating to production.
 
 To run:
-	1. First, if you don't already have a Databricks CLI profile named test_profile pointed at the tfs.cloud.databricks.com instance, please run Create_Test_Profile.bat. This script will walk you through the process of creating the test_profile.
-	
+	1. First, if you don't already have a Databricks CLI profile named test_profile pointed at the tfs.cloud.databricks.com instance, please run Create_Test_Profile.bat. This script will walk you through the process of creating the test_profile.	
 	2. Next, run Refresh_From_Databricks_TST.bat. This will refresh all of the code from Databricks non prod instance, and then run the two powershell scripts.
 		a. Check_For_Environment.ps1 runs a grep on environment=’TST’ (or DEV or PRD) saving the output into a .txt file named environment_chk.txt
 		b. Check_For_DB_Environment.ps1 runs a grep on db_environment=’test’ (or prod) saving the output into a .txt file named databricks_environment_chk.txt

--- a/utility_functions/migration_utilities/Readme.md
+++ b/utility_functions/migration_utilities/Readme.md
@@ -3,8 +3,8 @@ Author: Rich Winkler
 The scripts within this folder will assist in identifying any locations where environments have been hardcoded in scripts and should be changed when migrating to production.
 
 To run:
-	1. First, if you don't already have a Databricks CLI profile named test_profile pointed at the tfs.cloud.databricks.com instance, please run Create_Test_Profile.bat. This script will walk you through the process of creating the test_profile.	
-	2. Next, run Refresh_From_Databricks_TST.bat. This will refresh all of the code from Databricks non prod instance, and then run the two powershell scripts.
-		a. Check_For_Environment.ps1 runs a grep on environment=’TST’ (or DEV or PRD) saving the output into a .txt file named environment_chk.txt
-		b. Check_For_DB_Environment.ps1 runs a grep on db_environment=’test’ (or prod) saving the output into a .txt file named databricks_environment_chk.txt
-	3. Last, examine environment_chk.txt and databricks_environment_chk.txt for all instances to ensure that all environment hardcodings have been switched to production.
+1. First, if you don't already have a Databricks CLI profile named test_profile pointed at the tfs.cloud.databricks.com instance, please run Create_Test_Profile.bat. This script will walk you through the process of creating the test_profile.	
+2. Next, run Refresh_From_Databricks_TST.bat. This will refresh all of the code from Databricks non prod instance, and then run the two powershell scripts.
+	* Check_For_Environment.ps1 runs a grep on environment=’TST’ (or DEV or PRD) saving the output into a .txt file named environment_chk.txt
+	* Check_For_DB_Environment.ps1 runs a grep on db_environment=’test’ (or prod) saving the output into a .txt file named databricks_environment_chk.txt
+3. Last, examine environment_chk.txt and databricks_environment_chk.txt for all instances to ensure that all environment hardcodings have been switched to production.

--- a/utility_functions/migration_utilities/Readme.md
+++ b/utility_functions/migration_utilities/Readme.md
@@ -1,0 +1,11 @@
+Author: Rich Winkler
+
+The scripts within this folder will assist in identifying any locations where environments have been hardcoded in scripts and should be changed when migrating to production.
+
+To run:
+	1. First, if you don't already have a Databricks CLI profile named test_profile pointed at the tfs.cloud.databricks.com instance, please run Create_Test_Profile.bat. This script will walk you through the process of creating the test_profile.
+	
+	2. Next, run Refresh_From_Databricks_TST.bat. This will refresh all of the code from Databricks non prod instance, and then run the two powershell scripts.
+		a. Check_For_Environment.ps1 runs a grep on environment=’TST’ (or DEV or PRD) saving the output into a .txt file named environment_chk.txt
+		b. Check_For_DB_Environment.ps1 runs a grep on db_environment=’test’ (or prod) saving the output into a .txt file named databricks_environment_chk.txt
+	3. Last, examine environment_chk.txt and databricks_environment_chk.txt for all instances to ensure that all environment hardcodings have been switched to production.

--- a/utility_functions/migration_utilities/Refresh_From_Databricks_TST.bat
+++ b/utility_functions/migration_utilities/Refresh_From_Databricks_TST.bat
@@ -1,0 +1,9 @@
+call C:/Users/u00xbg/AppData/Local/Continuum/anaconda3/Scripts/activate.bat
+databricks workspace export_dir /DS_CCG/RSD_COE/Data_Scientists . -o --profile test_profile
+
+Powershell.exe -executionpolicy remotesigned -File  .\Check_For_Environment.ps1
+Powershell.exe -executionpolicy remotesigned -File  .\Check_For_DB_Environment.ps1
+
+ECHO "EXPORT COMPLETE"
+PAUSE
+exit


### PR DESCRIPTION
I already sent these scripts via email but they may be helpful for other analysts as they promote code into production. The "Refresh_From_Databricks_TST.bat" file requires a profile named "test_profile" to be set up first. If this isn't set up already, you can set one up using the "Create_Test_Profile.bat" file.