### PR TITLE
bound_date_check circular dependency

### DIFF
--- a/_tests/test_date_period.py
+++ b/_tests/test_date_period.py
@@ -24,5 +24,8 @@ class TestDatePeriod(TestCase):
                                                                     env='PRD',
                                                                     date_format=date_format)
 
+        self.assertLessEqual(min_date, max_date)
         self.assertTrue(min_date)
         self.assertTrue(max_date)
+        self.assertTrue(check_min)
+        self.assertTrue(check_max)

--- a/_tests/test_date_period.py
+++ b/_tests/test_date_period.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from utility_functions.date_period import find_time_points
+from utility_functions.date_period import find_time_points, bound_date_check
 
 
 class TestDatePeriod(TestCase):
@@ -9,3 +9,20 @@ class TestDatePeriod(TestCase):
         self.assertEqual(time_points[0], '20191231')
         self.assertEqual(time_points[1], '20200131')
         self.assertEqual(time_points[2], '20190101')
+
+    def test_bound_date_check(self):
+        """Tests to ensure the bound_date_check function is working"""
+        tbl = 'ccgds.f_sls_invc_model_vw'
+        dt_col_name = 'invc_dt'
+        start_date = '20200113'
+        end_date = '20200117'
+        date_format = 'YYYYMMDD'
+        check_max, check_min, max_date, min_date = bound_date_check(tbl,
+                                                                    dt_col_name,
+                                                                    start_date,
+                                                                    end_date,
+                                                                    env='PRD',
+                                                                    date_format=date_format)
+
+        self.assertTrue(min_date)
+        self.assertTrue(max_date)

--- a/utility_functions/date_period.py
+++ b/utility_functions/date_period.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 from typing import List, Tuple
-from connect2Databricks.read2Databricks import redshift_ccg_read, redshift_cdw_read
 from utility_functions.benchmark import timer
 from utility_functions.custom_errors import *
 from pyspark.sql import functions as F
@@ -123,6 +122,7 @@ def bound_date_check(
     :param division: enter either 'CCG' or 'LSG' to make sure it uses the correct credentials
     :return: check_max (TRUE or FALSE), check_min (TRUE or FALSE), max_date, min_date
     """
+    from connect2Databricks.read2Databricks import redshift_ccg_read, redshift_cdw_read
     test_query = ''
     if date_format == 'DATE':
         test_query = \


### PR DESCRIPTION
The read2Databricks imports create a circular dependency with connect2Databricks also importing utility functions. If we move the import into the function definition it will still work but without causing the circular import. I also added a test to ensure functionality of bound_date_check; test passed on the GSP_Data_Science_Small cluster.